### PR TITLE
Implement `shouldLoad()` in the BridgeComponent class based on the expected user-agent

### DIFF
--- a/dist/strada.js
+++ b/dist/strada.js
@@ -574,7 +574,7 @@ var BridgeElement = class {
 
 // src/helpers/user_agent.ts
 var { userAgent } = window.navigator;
-var isStradaMobileApp = /bridge-components: \[.+\]/.test(userAgent);
+var isStradaNativeApp = /bridge-components: \[.+\]/.test(userAgent);
 
 // src/bridge_component.ts
 var BridgeComponent = class extends Controller {
@@ -583,7 +583,7 @@ var BridgeComponent = class extends Controller {
     this.pendingMessageCallbacks = [];
   }
   static get shouldLoad() {
-    return isStradaMobileApp;
+    return isStradaNativeApp;
   }
   initialize() {
     this.pendingMessageCallbacks = [];

--- a/src/bridge_component.ts
+++ b/src/bridge_component.ts
@@ -2,13 +2,13 @@ import { Controller } from "stimulus"
 import { Bridge } from "./bridge"
 import { BridgeElement } from "./bridge_element"
 import { MessageCallback } from "./helpers/types"
-import { isStradaMobileApp } from "./helpers/user_agent"
+import { isStradaNativeApp } from "./helpers/user_agent"
 
 export class BridgeComponent extends Controller {
   static component = ""
 
   static get shouldLoad() {
-    return isStradaMobileApp
+    return isStradaNativeApp
   }
 
   pendingMessageCallbacks: Array<any> = []

--- a/src/helpers/user_agent.ts
+++ b/src/helpers/user_agent.ts
@@ -1,3 +1,3 @@
 const { userAgent } = window.navigator
 
-export const isStradaMobileApp = /bridge-components: \[.+\]/.test(userAgent)
+export const isStradaNativeApp = /bridge-components: \[.+\]/.test(userAgent)


### PR DESCRIPTION
Strada mobile apps must update their user-agent strings to include the registered bridge components. Here's an example of what it looks like in HEY:
```
Haystack Android/1.1.2 (build 93; Pixel 5; Android 11; Turbo Native) bridge-components: [page form ...]
```

This PR changes the default behavior to only load `BridgeComponent` controllers with the presence of **`bridge-components: [...]`** in the app's user-agent string.