### PR TITLE
Rename Component class -> BridgeComponent

### DIFF
--- a/dist/strada.js
+++ b/dist/strada.js
@@ -572,8 +572,8 @@ var BridgeElement = class {
   }
 };
 
-// src/component.ts
-var Component = class extends Controller {
+// src/bridge_component.ts
+var BridgeComponent = class extends Controller {
   constructor() {
     super(...arguments);
     this.pendingMessageCallbacks = [];
@@ -620,7 +620,7 @@ var Component = class extends Controller {
     return window.Strada.web;
   }
 };
-Component.component = "";
+BridgeComponent.component = "";
 
 // src/index.ts
 if (!window.Strada) {
@@ -629,6 +629,6 @@ if (!window.Strada) {
   webBridge.start();
 }
 export {
-  BridgeElement,
-  Component
+  BridgeComponent,
+  BridgeElement
 };

--- a/src/bridge_component.ts
+++ b/src/bridge_component.ts
@@ -3,7 +3,7 @@ import { Bridge } from "./bridge"
 import { BridgeElement } from "./bridge_element"
 import { MessageCallback } from "./helpers/types"
 
-export class Component extends Controller {
+export class BridgeComponent extends Controller {
   static component = ""
 
   pendingMessageCallbacks: Array<any> = []
@@ -20,7 +20,7 @@ export class Component extends Controller {
   }
 
   get component() {
-    return (this.constructor as typeof Component).component
+    return (this.constructor as typeof BridgeComponent).component
   }
 
   get platformOptingOut() {

--- a/src/bridge_element.ts
+++ b/src/bridge_element.ts
@@ -1,4 +1,4 @@
-import { Component } from "./component"
+import { BridgeComponent } from "./bridge_component"
 
 export class BridgeElement {
   element: Element
@@ -25,7 +25,7 @@ export class BridgeElement {
     return disabled === "true" || disabled === this.platform
   }
 
-  enableForComponent(component: Component) {
+  enableForComponent(component: BridgeComponent) {
     if (component.enabled) {
       this.removeBridgeAttribute("disabled")
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { Bridge } from "./bridge"
-export { Component } from "./component"
+export { BridgeComponent } from "./bridge_component"
 export { BridgeElement } from "./bridge_element"
 
 declare global {


### PR DESCRIPTION
Renaming `Component` -> `BridgeComponent` helps clarify the intent of the base class in apps